### PR TITLE
Add PKGBUILD to be used on Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,5 +115,23 @@ rpm:
 	rpmbuild -bb "$(HOME)/rpmbuild/SPECS/kyoto-tycoon.spec"
 	rpmbuild --clean "$(HOME)/rpmbuild/SPECS/kyoto-tycoon.spec"
 
+pac:
+	rm -rf $(HOME)/archbuild
+	mkdir $(HOME)/archbuild
+	test -d "$(HOME)/archbuild" && test -x /usr/bin/makepkg
+	cp "$(PWD)/arch/PKGBUILD" "$(HOME)/archbuild/PKGBUILD"
+	cp "$(PWD)/arch/service" "$(HOME)/archbuild/"
+	cp "$(PWD)/arch/kyoto.install" "$(HOME)/archbuild/"
+	cp "$(PWD)/arch/kyoto.conf" "$(HOME)/archbuild/"
+
+	$(eval PACKAGE_VERSION := $(shell grep _KT_VERSION kyototycoon/myconf.h | awk '{print $$3}' | sed 's/"//g'))
+	$(eval PACKAGE_DATE := $(shell date +%Y%m%d))
+
+	rm -f "$(HOME)/archbuild/kyoto-$(PACKAGE_VERSION).tar.gz"
+	tar zcf "$(HOME)/archbuild/kyoto-$(PACKAGE_VERSION).tar.gz" .
+
+	sed -i 's/__KT_VERSION_PLACEHOLDER__/$(PACKAGE_VERSION)/' "$(HOME)/archbuild/PKGBUILD"
+
+	cd $(HOME)/archbuild && makepkg --nocheck --skipinteg --skipchecksums --skippgpcheck
 
 # EOF - Makefile

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ pac:
 	mkdir $(HOME)/archbuild
 	test -d "$(HOME)/archbuild" && test -x /usr/bin/makepkg
 	cp "$(PWD)/arch/PKGBUILD" "$(HOME)/archbuild/PKGBUILD"
-	cp "$(PWD)/arch/service" "$(HOME)/archbuild/"
+	cp "$(PWD)/arch/kyoto.service" "$(HOME)/archbuild/"
 	cp "$(PWD)/arch/kyoto.install" "$(HOME)/archbuild/"
 	cp "$(PWD)/arch/kyoto.conf" "$(HOME)/archbuild/"
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ On RHEL/CentOS, create a `.rpm` package (into the `$HOME/rpmbuild/RPMS` director
 
 Besides being cleaner than installing directly from source, both of these packages provide an `/etc/init.d/kyoto` init script to run the server with minimal privileges and an `/etc/default/kyoto` configuration file with some examples.
 
+On Arch, create a `.pkg.tar.xz` package (into the `$HOME/archbuild/` directory) by running:
+
+    $ make pac
+
+This package provides a `systemd service` to run the server with minimal privileges and an `/etc/conf.d/kyoto` configuration file with some examples.
 
 Running
 -------

--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Dani Bento <danibento@overdestiny.com>
+
+pkgname=kyoto
+pkgver=__KT_VERSION_PLACEHOLDER__
+pkgrel=1
+pkgdesc="Kyoto Tycoon key-value server (and Kyoto Cabinet library)"
+arch=('i686' 'x86_64')
+url="http://github.com/sapo/kyoto"
+license=('GPL')
+depends=('lua' 'lua51')
+install=kyoto.install
+backup=('etc/conf.d/kyoto')
+
+kt_installdir=/usr
+
+build() {
+  tar -xvzf ../kyoto-__KT_VERSION_PLACEHOLDER__.tar.gz -C .
+  make PREFIX=/usr DESTDIR="${pkgdir}/"
+}
+
+package() {
+
+  make install DESTDIR="$pkgdir/"
+
+  mkdir -p $pkgdir/var/lib/kyoto
+  mkdir -p $pkgdir/etc/default
+	
+  install -d -m755 "${pkgdir}/etc/conf.d"
+  install -D -m644 "$srcdir/scripts/kyoto.conf" "${pkgdir}/etc/conf.d/kyoto"
+  install -D -m644 "$srcdir/arch/kyoto.conf" "${pkgdir}/usr/lib/tmpfiles.d/kyoto.conf"
+  install -D -m644 "$srcdir/arch/service" "${pkgdir}/usr/lib/systemd/system/kyoto.service"
+  install -D -m644 "$srcdir/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+}
+
+sha512sums=('278db7b327eb4c21bf0137d9aa14fb67d74d5ce7ed1cb29fc9120d157a60de165ec0cf842903eb7952e8f998045ae585b958977fa973ba0e0773381de71d9f6a')

--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -28,7 +28,7 @@ package() {
   install -d -m755 "${pkgdir}/etc/conf.d"
   install -D -m644 "$srcdir/scripts/kyoto.conf" "${pkgdir}/etc/conf.d/kyoto"
   install -D -m644 "$srcdir/arch/kyoto.conf" "${pkgdir}/usr/lib/tmpfiles.d/kyoto.conf"
-  install -D -m644 "$srcdir/arch/service" "${pkgdir}/usr/lib/systemd/system/kyoto.service"
+  install -D -m644 "$srcdir/arch/kyoto.service" "${pkgdir}/usr/lib/systemd/system/kyoto.service"
   install -D -m644 "$srcdir/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 
 }

--- a/arch/kyoto.conf
+++ b/arch/kyoto.conf
@@ -1,3 +1,4 @@
 d /var/lib/kyoto 0755 kyoto kyoto -
 x /var/lib/kyoto/*
-f /var/log/kyoto.log 0755 kyoto kyoto -
+f /var/log/kyoto.log kyoto kyoto -
+D /run/kyoto 0775 kyoto kyoto -

--- a/arch/kyoto.conf
+++ b/arch/kyoto.conf
@@ -1,0 +1,3 @@
+d /var/lib/kyoto 0755 kyoto kyoto -
+x /var/lib/kyoto/*
+f /var/log/kyoto.log 0755 kyoto kyoto -

--- a/arch/kyoto.install
+++ b/arch/kyoto.install
@@ -1,0 +1,44 @@
+#!/bin/sh
+post_install() {
+	echo "Creating user/group kyoto for KT"
+
+	# Create the service user for KT...
+	if ! grep -q "kyoto" /etc/group; then
+		groupadd -r kyoto
+	fi
+
+	# Create the service user for KT...
+	if ! grep -q "kyoto" /etc/passwd; then
+		useradd -r -M -d /var/lib/kyoto -g kyoto -s /bin/false kyoto
+	fi
+
+	chown kyoto:kyoto /var/lib/kyoto
+	
+	systemd-tmpfiles --create kyoto.conf	
+	systemctl daemon-reload
+
+	exit 0
+}
+
+post_upgrade() {
+	
+	systemctl daemon-reload
+
+	exit 0
+}
+
+post_remove() {
+	# Remove the service user for KT...
+	if grep -q "kyoto" /etc/passwd; then
+		pkill -KILL -U "kyoto" || true
+		userdel "kyoto"
+	fi
+
+	# Also remove the service group if it wasn't removed automatically...
+	if grep -q "kyoto" /etc/group; then
+		groupdel "kyoto"
+	fi
+
+	exit 0
+}
+# vim:set ts=2 sw=2 et:

--- a/arch/kyoto.service
+++ b/arch/kyoto.service
@@ -4,7 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=forking
-PIDFile=/run/kyoto.pid
+PIDFile=/run/kyoto/kyoto.pid
 PrivateDevices=yes
 SyslogLevel=err
 Restart=on-abort	
@@ -12,11 +12,10 @@ User=kyoto
 Group=kyoto
 
 EnvironmentFile=/etc/conf.d/kyoto
-ExecStartPre=/bin/rm -f '/run/kyoto.pid'; chown kyoto.kyoto /var/log/kyoto.log
-ExecStart=/usr/bin/ktserver -dmn -pid /run/kyoto.pid -log /var/log/kyoto.log $KTSERVER_OPTS
-ExecReload=/usr/bin/kill -HUP /run/kyoto.pid
-KillSignal=SIGQUIT
-KillMode=mixed
+ExecStart=/usr/bin/ktserver -dmn -pid /run/kyoto/kyoto.pid -log /var/log/kyoto.log $KTSERVER_OPTS
+ExecStop=/usr/bin/kill -TERM /run/kyoto/kyoto.pid
+ExecReload=/usr/bin/kill -HUP /run/kyoto/kyoto.pid
+KillSignal=SIGTERM
 
 [Install]
 WantedBy=multi-user.target

--- a/arch/service
+++ b/arch/service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Kyoto Tycoon key-value server (and Kyoto Cabinet library)
+After=syslog.target network.target
+
+[Service]
+Type=forking
+PIDFile=/run/kyoto.pid
+PrivateDevices=yes
+SyslogLevel=err
+Restart=on-abort	
+User=kyoto
+Group=kyoto
+
+EnvironmentFile=/etc/conf.d/kyoto
+ExecStartPre=/bin/rm -f '/run/kyoto.pid'; chown kyoto.kyoto /var/log/kyoto.log
+ExecStart=/usr/bin/ktserver -dmn -pid /run/kyoto.pid -log /var/log/kyoto.log $KTSERVER_OPTS
+ExecReload=/usr/bin/kill -HUP /run/kyoto.pid
+KillSignal=SIGQUIT
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change contains the basic structure to build the kyoto server in a Arch Linux environment. Besides this, it create a basic configuration for a SystemD service.
