### PR TITLE
fix: permissions and install script

### DIFF
--- a/packaging/arch/kyoto.conf
+++ b/packaging/arch/kyoto.conf
@@ -1,4 +1,4 @@
 d /var/lib/kyoto 0755 kyoto kyoto -
 x /var/lib/kyoto/*
-f /var/log/kyoto.log kyoto kyoto -
+f /var/log/kyoto.log 0755 kyoto kyoto -
 D /run/kyoto 0775 kyoto kyoto -

--- a/packaging/arch/kyoto.install
+++ b/packaging/arch/kyoto.install
@@ -22,12 +22,16 @@ post_install() {
 
 post_upgrade() {
 	
+  systemd-tmpfiles --create kyoto.conf
 	systemctl daemon-reload
 
 	exit 0
 }
 
 post_remove() {
+
+  systemctl daemon-reload
+
 	# Remove the service user for KT...
 	if grep -q "kyoto" /etc/passwd; then
 		pkill -KILL -U "kyoto" || true
@@ -38,6 +42,10 @@ post_remove() {
 	if grep -q "kyoto" /etc/group; then
 		groupdel "kyoto"
 	fi
+
+  if [ -d /run/kyoto/ ]; then
+    rm -rf /run/kyoto
+  fi
 
 	exit 0
 }


### PR DESCRIPTION
- add permission mode for tmpfiles.d (gives Resources
  error when started with systemctl using the kyoto.conf)
- update tmpfiles.d after upgrade
- reload systemctl daemon after remove (cleaning the
  kyoto.service)
- clean temporary /run directory
