### PR TITLE
Correcting NPROC variable value of Darwin and FreeBSD in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ ifeq ($(OS),Linux)
 	NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 endif
 ifeq ($(OS),Darwin)
-	NPROCS := $(shell sysctl -a | grep "hw.ncpu " | cut -d" " -f3)
+	NPROCS := $(shell sysctl -a | grep "hw.ncpu" | cut -d" " -f2)
 endif
 ifeq ($(OS),FreeBSD)
-	NPROCS := $(shell sysctl -a | grep "hw.ncpu " | cut -d" " -f3)
+	NPROCS := $(shell sysctl -a | grep "hw.ncpu" | cut -d" " -f2)
 endif
 
 # For dependencies below...


### PR DESCRIPTION
I've fixing Makefile NPROCS variable and testing in OS X Yosemite, El Capitan and FreeBSD 10.3-RELEASE.
Please review, Thank you.
