### PR TITLE
Fix CPU detection for parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ ifeq ($(OS),Linux)
 	NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
 endif
 ifeq ($(OS),Darwin)
-	NPROCS := $(shell sysctl -a | grep "hw.ncpu " | cut -d" " -f3)
+	NPROCS := $(shell sysctl "hw.ncpu" | grep -o "[0-9]\+\$$")
 endif
 ifeq ($(OS),FreeBSD)
-	NPROCS := $(shell sysctl -a | grep "hw.ncpu " | cut -d" " -f3)
+	NPROCS := $(shell sysctl "hw.ncpu" | grep -o "[0-9]\+\$$")
 endif
 
 # For dependencies below...

--- a/kyototycoon/ktutilserv.cc
+++ b/kyototycoon/ktutilserv.cc
@@ -338,7 +338,7 @@ static int32_t procecho(const char* host, int32_t port, double tout) {
           } else {
             eprintf("%s: server: accept error: %s\n", g_progname, serv.error());
             err = true;
-            delete[] sock;
+            delete sock;
           }
           serv.set_event_flags(kt::Pollable::EVINPUT);
           if (!poll.undo(&serv)) {


### PR DESCRIPTION
This fixes the CPU detection issues mentioned in PR https://github.com/alticelabs/kyoto/pull/14. It also fixes a `new/delete[]` allocation mismatch detected by `clang` while testing.

Tested in MacOS X 10.8 (Mountain Lion) and 10.11 (El Capitan).
