### PR TITLE
Exclude documentation from GitHub stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+kyototycoon/doc/* linguist-documentation
+kyotocabinet/doc/* linguist-documentation


### PR DESCRIPTION
GitHub thinks Kyoto is mostly HTML. This fixes it.
