### PR TITLE
Minor updates and fixes for recent compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Download our latest _stable_ [source release](https://github.com/alticelabs/kyot
 
 **Notes:**
 
-  * Make sure you have [zlib](http://www.zlib.net/), [lzo](http://www.oberhumer.com/opensource/lzo/) and [Lua 5.1.x](http://www.lua.org/versions.html#5.1) already installed;
+  * Make sure you have [zlib](http://www.zlib.net/), [lzo](http://www.oberhumer.com/opensource/lzo/) and [Lua 5.1.x](http://www.lua.org/versions.html#5.1) (or [LuaJIT](http://luajit.org/)) already installed;
   * The installation root directory (`PREFIX`) is optional. By default it already installs into `/usr/local`;
   * If you're building on FreeBSD, use `gmake` from the ports collection instead of standard `make`.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(2) do |config|
 
     # Debian is the default/primary development environment...
     config.vm.define "debian", primary: true do |debian|
-        debian.vm.box = "debian/jessie64"
+        debian.vm.box = "debian/stretch64"
         debian.vm.hostname = "kyoto-dev-debian"
 
         debian.vm.provider "virtualbox" do |vm, override|

--- a/kyotocabinet/configure
+++ b/kyotocabinet/configure
@@ -671,6 +671,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -755,6 +756,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1007,6 +1009,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1144,7 +1155,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1297,6 +1308,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/kyototycoon/configure
+++ b/kyototycoon/configure
@@ -672,6 +672,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -756,6 +757,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1008,6 +1010,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1145,7 +1156,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1298,6 +1309,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/kyototycoon/configure
+++ b/kyototycoon/configure
@@ -2280,13 +2280,17 @@ if test "$enable_lua" = "yes"
 then
   MYCPPFLAGS="$MYCPPFLAGS -D_MYLUA"
 
-  for luaincpath in /usr/include/lua5.1 \
+  for luaincpath in /usr/include/luajit-2.1 \
+                    /usr/include/luajit-2.0 \
+                    /usr/include/lua5.1 \
                     /usr/include/lua-5.1 \
                     /usr/include/lua51 \
+                    /usr/include/lua \
+                    /usr/local/include/luajit-2.1 \
+                    /usr/local/include/luajit-2.0 \
                     /usr/local/include/lua5.1 \
                     /usr/local/include/lua-5.1 \
                     /usr/local/include/lua51 \
-                    /usr/include/lua \
                     /usr/local/include/lua
   do
     if test -e $luaincpath
@@ -2297,13 +2301,17 @@ then
     fi
   done
 
-  for lualibpath in /usr/lib/lua5.1 \
+  for lualibpath in /usr/lib/luajit-2.1 \
+                    /usr/lib/luajit-2.0 \
+                    /usr/lib/lua5.1 \
                     /usr/lib/lua-5.1 \
                     /usr/lib/lua51 \
+                    /usr/lib/lua \
+                    /usr/local/lib/luajit-2.1 \
+                    /usr/local/lib/luajit-2.0 \
                     /usr/local/lib/lua5.1 \
                     /usr/local/lib/lua-5.1 \
                     /usr/local/lib/lua51 \
-                    /usr/lib/lua \
                     /usr/local/lib/lua
   do
     if test -e $lualibpath
@@ -4031,7 +4039,7 @@ fi
 
 if test "$enable_lua" = "yes"
 then
-  for lualib in lua5.1 lua-5.1 lua51 lua
+  for lualib in luajit-5.1 lua5.1 lua-5.1 lua51 lua
   do
     as_ac_Lib=`$as_echo "ac_cv_lib_$lualib''_main" | $as_tr_sh`
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -l$lualib" >&5

--- a/kyototycoon/configure
+++ b/kyototycoon/configure
@@ -4059,6 +4059,10 @@ fi
 
     if echo $MYCMDLIBS | grep -q lua
     then
+      if echo $LIBS | grep -q "\-ldl\b"
+      then
+        MYCMDLIBS="$MYCMDLIBS -ldl"
+      fi
       break
     fi
   done

--- a/kyototycoon/configure.in
+++ b/kyototycoon/configure.in
@@ -276,6 +276,10 @@ then
     AC_CHECK_LIB($lualib, main, MYCMDLIBS="$MYCMDLIBS -l$lualib")
     if echo $MYCMDLIBS | grep -q lua
     then
+      if echo $LIBS | grep -q "\-ldl\b"
+      then
+        MYCMDLIBS="$MYCMDLIBS -ldl"
+      fi
       break
     fi
   done

--- a/kyototycoon/configure.in
+++ b/kyototycoon/configure.in
@@ -144,13 +144,17 @@ if test "$enable_lua" = "yes"
 then
   MYCPPFLAGS="$MYCPPFLAGS -D_MYLUA"
 
-  for luaincpath in /usr/include/lua5.1 \
+  for luaincpath in /usr/include/luajit-2.1 \
+                    /usr/include/luajit-2.0 \
+                    /usr/include/lua5.1 \
                     /usr/include/lua-5.1 \
                     /usr/include/lua51 \
+                    /usr/include/lua \
+                    /usr/local/include/luajit-2.1 \
+                    /usr/local/include/luajit-2.0 \
                     /usr/local/include/lua5.1 \
                     /usr/local/include/lua-5.1 \
                     /usr/local/include/lua51 \
-                    /usr/include/lua \
                     /usr/local/include/lua
   do
     if test -e $luaincpath
@@ -161,13 +165,17 @@ then
     fi
   done
 
-  for lualibpath in /usr/lib/lua5.1 \
+  for lualibpath in /usr/lib/luajit-2.1 \
+                    /usr/lib/luajit-2.0 \
+                    /usr/lib/lua5.1 \
                     /usr/lib/lua-5.1 \
                     /usr/lib/lua51 \
+                    /usr/lib/lua \
+                    /usr/local/lib/luajit-2.1 \
+                    /usr/local/lib/luajit-2.0 \
                     /usr/local/lib/lua5.1 \
                     /usr/local/lib/lua-5.1 \
                     /usr/local/lib/lua51 \
-                    /usr/lib/lua \
                     /usr/local/lib/lua
   do
     if test -e $lualibpath
@@ -271,7 +279,7 @@ AC_CHECK_LIB(kyotocabinet, main)
 AC_CHECK_LIB(kyotocabinet, main, MYCMDLIBS="$MYCMDLIBS -lkyotocabinet")
 if test "$enable_lua" = "yes"
 then
-  for lualib in lua5.1 lua-5.1 lua51 lua
+  for lualib in luajit-5.1 lua5.1 lua-5.1 lua51 lua
   do
     AC_CHECK_LIB($lualib, main, MYCMDLIBS="$MYCMDLIBS -l$lualib")
     if echo $MYCMDLIBS | grep -q lua

--- a/kyototycoon/ktulog.h
+++ b/kyototycoon/ktulog.h
@@ -47,8 +47,8 @@ class UpdateLogger {
   static const uint64_t TSWACC = 1000;
   /* The accuracy of logical time stamp. */
   static const uint64_t TSLACC = 1000 * 1000;
-  /* The waiting seconds of auto flush. */
-  static const double FLUSHWAIT = 0.1;
+  /* The waiting milliseconds of auto flush. */
+  static const uint32_t FLUSHWAIT = 100;
  public:
   /**
    * Reader of update logs.
@@ -511,7 +511,7 @@ class UpdateLogger {
     void run() {
       double asnext = 0;
       while (alive_ && !error_) {
-        kc::Thread::sleep(FLUSHWAIT);
+        kc::Thread::sleep(FLUSHWAIT/1000.0);
         if (ulog_->clock_.lock_try()) {
           if (ulog_->csiz_ > 0 && !ulog_->flush()) error_ = true;
           ulog_->clock_.unlock();

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -4,7 +4,7 @@ Maintainer: Carlos Rodrigues <cefrodrigues@gmail.com>
 Homepage: https://github.com/alticelabs/kyoto
 Priority: optional
 Section: misc
-Build-Depends: zlib1g-dev, liblua5.1-0-dev, liblzo2-dev
+Build-Depends: zlib1g-dev, liblua5.1-0-dev | libluajit-5.1-dev, liblzo2-dev
 Depends: adduser, lsb-base
 Description: Kyoto Tycoon key-value server (and Kyoto Cabinet library)
  .

--- a/packaging/debian/kyoto-init.sh
+++ b/packaging/debian/kyoto-init.sh
@@ -34,7 +34,6 @@ case $1 in
 	start)
 		log_daemon_msg "Starting Kyoto Tycoon server" "kyoto"
 		start-stop-daemon --start --quiet --pidfile $PIDFILE --chuid $RUNASUSER --startas $DAEMON -- $KTSERVER_OPTS
-		$0 status >/dev/null
 		log_end_msg $?
 		;;
 	stop)

--- a/packaging/redhat/kyoto-tycoon.spec
+++ b/packaging/redhat/kyoto-tycoon.spec
@@ -21,7 +21,13 @@ License: GPLv3
 URL: https://github.com/alticelabs/kyoto
 Source0: kyoto-%{kt_timestamp}.tar.gz
 
-BuildRequires: lua-devel, zlib-devel, lzo-devel
+%if ("%(rpm -q --queryformat=1 luajit-devel)" == "1")
+BuildRequires: luajit-devel
+%else
+BuildRequires: lua-devel
+%endif
+
+BuildRequires: zlib-devel, lzo-devel
 Requires: /bin/grep, /bin/true, /bin/false
 Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd
 Requires(preun): /usr/bin/pkill

--- a/packaging/redhat/kyoto-tycoon.spec
+++ b/packaging/redhat/kyoto-tycoon.spec
@@ -87,7 +87,7 @@ server and the API reference for the bundled Kyoto Cabinet library.
 
 
 %build
-make PREFIX=%{kt_installdir}
+make PREFIX=%{kt_installdir} KC_OPTIONS="--enable-lzo" KT_OPTIONS="--enable-lua"
 
 
 %install


### PR DESCRIPTION
This PR includes the support for LuaJIT during the build phase, which is now preferred to Lua 5.1 (no longer supported by its upstream). It also fixes an issue that may prevent compilation with C++11 compilers.