### PR TITLE
Fix compilation with C+11 (requires constexpr)

### DIFF
--- a/kyototycoon/ktulog.h
+++ b/kyototycoon/ktulog.h
@@ -21,6 +21,12 @@
 
 #define KTULPATHEXT  "ulog"              ///< extension of each file
 
+#if __cplusplus >= 201103L
+#define CONSTEXPR constexpr
+#else
+#define CONSTEXPR const
+#endif
+
 namespace kyototycoon {                  // common namespace
 
 
@@ -48,7 +54,7 @@ class UpdateLogger {
   /* The accuracy of logical time stamp. */
   static const uint64_t TSLACC = 1000 * 1000;
   /* The waiting seconds of auto flush. */
-  static const double FLUSHWAIT = 0.1;
+  static CONSTEXPR double FLUSHWAIT = 0.1;
  public:
   /**
    * Reader of update logs.


### PR DESCRIPTION
There is a different approach in #26 by @carlosefr already, this one is more about compiling.

C++11 now requires `constexpr` for non-int expressions, while older C++ still requires `const`.